### PR TITLE
need syslog-ng-libdbi

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,6 +8,10 @@ class syslog_ng::install {
   package { 'syslog-ng':
     ensure => installed,
   }
+  package { 'syslog-ng-libdbi':
+    ensure => installed,
+    required => Package['syslog-ng'],
+  }
   package { 'rsyslog':
     ensure => absent,
   }


### PR DESCRIPTION
without syslog-ng-libdbi restart syslog-ng complains like below

Plugin module not found in 'module-path'; module-path='/lib64/syslog-ng', module='afsql'
Starting syslog-ng: Plugin module not found in 'module-path'; module-path='/lib64/syslog-ng', module='afsql'